### PR TITLE
Change .collection_names to .listCollections 

### DIFF
--- a/scrapy_pipelines/pipelines/mongo.py
+++ b/scrapy_pipelines/pipelines/mongo.py
@@ -134,7 +134,7 @@ class MongoPipeline(ItemPipeline):
                 name=self.settings.get("PIPELINE_MONGO_USERNAME"),
             )
         try:
-            yield self.database.collection_names()
+            yield self.database.command("listCollections")
         except OperationFailure as err:
             LOGGER.error(str(err))
             self.crawler.engine.close_spider(spider=spider, reason=str(err))


### PR DESCRIPTION
Change .collection_names to listCollections (see [txmongo #209](https://github.com/twisted/txmongo/issues/209)) since collection_names requires access to system.namespace, that has been discontinues in Mongo >3.x.