### PR TITLE
Allow authentication from AUTH_SOURCE

### DIFF
--- a/scrapy_pipelines/pipelines/mongo.py
+++ b/scrapy_pipelines/pipelines/mongo.py
@@ -129,10 +129,14 @@ class MongoPipeline(ItemPipeline):
                     self.settings.get("PIPELINE_MONGO_PASSWORD"),
                 )
         ):
+
+            if self.settings.get("PIPELINE_MONGO_AUTH_SOURCE"):
+                database = self.settings.get("PIPELINE_MONGO_AUTH_SOURCE")
+            else:
+                database = self.settings.get("PIPELINE_MONGO_DATABASE")
             yield self._get_callable(
-                self.database.authenticate,
-                name=self.settings.get("PIPELINE_MONGO_USERNAME"),
-            )
+                self.mongo.authenticate,
+                database=database)
         try:
             yield self.database.collection_names()
         except OperationFailure as err:


### PR DESCRIPTION
Add PIPELINE_MONGO_AUTH_SOURCE option to allow the user to authenticate against a different database (different than PIPELINE_MONGO_DATABASE)